### PR TITLE
Add intraday trading strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ vops=ws://ops.koreainvestment.com:31000
 svr=vps
 product=01
 stock_code=005930
+strategy=simple
+# For intraday strategy specify comma separated codes
+stock_codes=005930

--- a/README.md
+++ b/README.md
@@ -422,6 +422,10 @@ KIS Developers 서비스 가입 후 HTS ID를 변경하여 '처리계좌의 ID�
 |websocket|ws_real_multiple_stocks.py|python|
 |websocket|ws_realstkprice.py|python|
 |websocket|ws_realstkquote.py|python|
+## 4-1. Auto Trade Examples
+자동 매매 샘플은 `auto_trade` 디렉터리에 있습니다. `.env` 파일을 설정한 후 `python -m auto_trade.main` 명령으로 실행할 수 있습니다.
+`strategy` 값을 `intraday` 로 지정하면 장중 실시간 가격을 확인하며 매매를 수행합니다.
+
 
 ## 5. Wikidocs(참고 교안)
 |구분|도서명|지원언어|링크|

--- a/auto_trade/main.py
+++ b/auto_trade/main.py
@@ -1,6 +1,7 @@
 from auto_trade.config import load_env, apply_to_kis_api
 import rest.kis_api as kis_api
 from auto_trade.strategies.simple import MovingAverageStrategy
+from auto_trade.strategies.intraday import IntradayTradingStrategy
 
 
 def main():
@@ -9,11 +10,18 @@ def main():
 
     svr = env.get('svr', 'vps')
     product = env.get('product', '01')
-    stock_code = env.get('stock_code', '005930')
+    strategy_name = env.get('strategy', 'simple')
 
     kis_api.auth(svr=svr, product=product)
 
-    strategy = MovingAverageStrategy(kis_api, stock_code)
+    if strategy_name == 'intraday':
+        codes = env.get('stock_codes', env.get('stock_code', '005930')).split(',')
+        codes = [c.strip() for c in codes if c.strip()]
+        strategy = IntradayTradingStrategy(kis_api, codes)
+    else:
+        stock_code = env.get('stock_code', '005930')
+        strategy = MovingAverageStrategy(kis_api, stock_code)
+
     strategy.execute()
 
 

--- a/auto_trade/strategies/intraday.py
+++ b/auto_trade/strategies/intraday.py
@@ -1,0 +1,47 @@
+from .base import BaseStrategy
+import time
+import pandas as pd
+
+class IntradayTradingStrategy(BaseStrategy):
+    """Simple intraday trading using moving average on real-time prices."""
+
+    def __init__(self, api, stock_codes, window=5, interval=60):
+        super().__init__(api)
+        self.stock_codes = stock_codes
+        self.window = window
+        self.interval = interval
+        self.histories = {code: [] for code in stock_codes}
+
+    def _update_price(self, code):
+        info = self.api.get_current_price(code)
+        price = int(info.get('stck_prpr', 0))
+        hist = self.histories[code]
+        hist.append(price)
+        if len(hist) > self.window:
+            hist.pop(0)
+        if len(hist) < self.window:
+            return price, None
+        return price, sum(hist) / len(hist)
+
+    def _is_holding(self, balance, code):
+        if balance.empty or code not in balance.index:
+            return False
+        qty = int(balance.loc[code]['보유수량'])
+        return qty > 0
+
+    def execute(self):
+        print(f"Starting intraday trading for: {', '.join(self.stock_codes)}")
+        while True:
+            balance = self.api.get_acct_balance()
+            for code in self.stock_codes:
+                price, ma = self._update_price(code)
+                if ma is None:
+                    continue
+                holding = self._is_holding(balance, code)
+                if not holding and price > ma:
+                    print(f"Buying {code} at {price}")
+                    self.api.do_buy(code, 1, price)
+                elif holding and price < ma:
+                    print(f"Selling {code} at {price}")
+                    self.api.do_sell(code, 1, price)
+            time.sleep(self.interval)


### PR DESCRIPTION
## Summary
- add intraday strategy that monitors prices continuously
- allow selecting strategy through `.env` file
- update example environment variables
- document auto trade usage in README

## Testing
- `python -m py_compile auto_trade/strategies/intraday.py auto_trade/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685a80e2a09883229d1dd9ef2c7fb525